### PR TITLE
ICR Document Status Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ You can view and run this locally using a local static file server. Some example
 
 ## Changelog
 
+vNext
+- Add response object to ICR DocumentsAvailable callback
+- Change Decision models of `id` to a named id: `loanId`, `conditionId`
+- Added `filename` back to Decision `inputDocuments`
+- Added new ICR status codes
+
 v0.10.0
 - Change `ezToClose` to `insuranceScore`
 - Decision documents to/from all have id, bucket, path, and no filename

--- a/README.md
+++ b/README.md
@@ -21,13 +21,16 @@ You can view and run this locally using a local static file server. Some example
 
 ## Changelog
 
-v0.11.0-rc.1
+### v0.11.0-rc.2
+- Updated Document status codes across all entities
+
+### v0.11.0-rc.1
 - Add response object to ICR DocumentsAvailable callback
 - Change Decision models of `id` to a named id: `loanId`, `conditionId`
 - Added `filename` back to Decision `inputDocuments`
 - Added new ICR status codes
 
-v0.10.0
+### v0.10.0
 - Change `ezToClose` to `insuranceScore`
 - Decision documents to/from all have id, bucket, path, and no filename
 - Add `parentId` to `documentsProcessed`
@@ -35,38 +38,38 @@ v0.10.0
 - Added required Decisions' property `outputtype: "Json"`
 - Changed input/output/documentsProcessed `id` to `fileId`, and changed `parentId` to `parentFileId`
 
-v0.9.1
+### v0.9.1
 - Updated `FNM32` to instead be `URLA`: Universal Residential Loan Application
 
-v0.9.0
+### v0.9.0
 - Added a way for an ICR to report that a previously processed output file has been marked as deleted and should not be considered for further processing
 - Update Swagger UI to v3.46.0
 
-v0.8.1
+### v0.8.1
 - Fixed the `$.outputDocuments.path` examples for Decisions' Process Loan Documents
 - Update Swagger UI to v3.45.1
 
-v0.8.0
+### v0.8.0
 - Changed ICR file download URL structure. Consumers shouldn't be affected by this change as the full proper URL is provided to them in the `DocumentsAvailable` callback.
 - Fixed misspelling of `FNM32`
 - Updated Swagger UI to v3.45.0
 
-v0.7.0
+### v0.7.0
 - Allow ability to overwrite previously uploaded document
 - Send filename to Decisions in `inputDocuments` and `outputDocuments`
 
-v0.6.0
+### v0.6.0
 - Added header authentication option to ICR callback registration
 
-v0.5.0
+### v0.5.0
 - Renamed the term "file" to "document" in relation to documents associated with a loan to avoid the confusion with the term "loan file" (the overall loan application file)
 
-v0.4.0
+### v0.4.0
 - Added enum values and descriptions
 - Fixed some required fields
 - Upper cased the `responseType` values and clarified how this controls the response of the process loan request
 - Added description to Download Document endpoint
 - Added recommendation for usable characters in the Document Id
 
-v0.3.0
+### v0.3.0
 - initial publish

--- a/README.md
+++ b/README.md
@@ -21,14 +21,12 @@ You can view and run this locally using a local static file server. Some example
 
 ## Changelog
 
-### v0.11.0-rc.2
-- Updated Document status codes across all entities
-
-### v0.11.0-rc.1
+### v0.11.0
 - Add response object to ICR DocumentsAvailable callback
 - Change Decision models of `id` to a named id: `loanId`, `conditionId`
 - Added `filename` back to Decision `inputDocuments`
 - Added new ICR status codes
+- Updated Document status codes across all entities
 
 ### v0.10.0
 - Change `ezToClose` to `insuranceScore`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can view and run this locally using a local static file server. Some example
 
 ## Changelog
 
-vNext
+v0.11.0-rc.1
 - Add response object to ICR DocumentsAvailable callback
 - Change Decision models of `id` to a named id: `loanId`, `conditionId`
 - Added `filename` back to Decision `inputDocuments`

--- a/decisions.openapi.yaml
+++ b/decisions.openapi.yaml
@@ -38,9 +38,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CandorResultSync'
+                $ref: '#/components/schemas/CandorResultsSync'
               example:
-                id: c8e27489-0381-438f-8148-4b7a2379a64c
+                loanId: c8e27489-0381-438f-8148-4b7a2379a64c
                 candorId: 68098e32-ce8f-41a9-9ce7-7127514348f2
                 runId: 1
                 timestamp: '0001-01-01T00:00:00Z'
@@ -56,8 +56,8 @@ paths:
                 assets: Pending
                 income: Pending
                 conditions:
-                - id: 151ce1d9-90e2-4e32-9337-8de6d8124e50
-                  status: 0
+                - conditionId: 151ce1d990e24e32
+                  status: 'Unfulfilled'
                   name: Condition Name
                   description: Extended descriptive text for this condition
                   priorTo: PTD
@@ -72,7 +72,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CandorResultAsync'
+                type: object
+                title: Asynchronous Candor Result
+                properties:
+                  candorId:
+                    $ref: '#/components/schemas/CandorId'
               example:
                 candorId: 68098e32-ce8f-41a9-9ce7-7127514348f2
         default:
@@ -121,7 +125,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CandorResultCallback'
+              $ref: '#/components/schemas/CandorResultsAsync'
       responses:
         '200':
           description: Ok
@@ -164,13 +168,13 @@ components:
       allOf:
         - $ref: 'schemas.yaml#/components/schemas/ProcessLoanBase'
       required:
-      - id
+      - loanId
       - customerId
       - sessionid
       - outputtype
       - loanData
       properties:
-        id:
+        loanId:
           $ref: 'schemas.yaml#/components/schemas/LoanId'
         customerId:
           $ref: '#/components/schemas/CustomerId'
@@ -198,7 +202,7 @@ components:
     ProcessDocuments:
       type: object
       required:
-      - id
+      - loanId
       - context
       - candorId
       - sessionid
@@ -206,7 +210,7 @@ components:
       - inputDocuments
       - outputDocuments
       properties:
-        id:
+        loanId:
           $ref: 'schemas.yaml#/components/schemas/LoanId'
         context:
           $ref: 'schemas.yaml#/components/schemas/Context'
@@ -227,6 +231,9 @@ components:
             required:
             - status
             properties:
+              filename:
+                type: string
+                description: The LOS filename of this Document.
               status:
                 type: object
                 description: |
@@ -264,30 +271,14 @@ components:
                 default: false
                 description: If this is true, then the file that was previously uploaded should be marked as deleted and not used for further processing.
 
-    CandorResultSync:
+    CandorResultsSync:
       type: object
-      title: Synchronous Candor Result
+      title: Candor Results
       allOf:
         - $ref: 'schemas.yaml#/components/schemas/CandorResult'
       properties:
         candorId:
           $ref: '#/components/schemas/CandorId'
-        customerId:
-          $ref:  "#/components/schemas/CustomerId"
-
-    CandorResultAsync:
-      type: object
-      title: Asynchronous Candor Result
-      properties:
-        candorId:
-          $ref: '#/components/schemas/CandorId'
-
-    CandorResultCallback:
-      type: object
-      title: Candor Result
-      allOf:
-        - $ref: 'schemas.yaml#/components/schemas/CandorResult'
-      properties:
         documentsProcessed:
           type: array
           items:
@@ -311,6 +302,7 @@ components:
                       The processed status for this document
 
                       - 200: Successfully ICR'd
+                      - 250: Partially ICR'd
                       - 300: Duplicate Document Uploaded
                       - 400: Document Corrupted, Unable to open, or Editable pdf
                       - 401: Unable to match Borrower name on document to applicant; Lender to review
@@ -319,9 +311,11 @@ components:
                       - 404: Unable to match Company Name on document to application; Lender to review
                       - 405: Document is outdated per guideline requirements
                       - 406: Successfully ICR'd
+                      - 415: Out of scope document
                       - 500: Ineligible Document
                     enum:
                     - 200
+                    - 250
                     - 300
                     - 400
                     - 401
@@ -330,15 +324,26 @@ components:
                     - 404
                     - 405
                     - 406
+                    - 415
                     - 500
                   message:
                     type: string
+
+    CandorResultsAsync:
+      allOf:
+        - $ref: '#/components/schemas/CandorResultsSync'
+      properties:
+        emails:
+          type: array
+          description: A list of emails to notify when a Candor Result is processed that contained new documents uploaded to the loan.
+          items:
+            type: string
 
   examples:
     ProcessLoanReqSync:
       summary: Synchronous Process Loan Request
       value:
-        id: c8e27489-0381-438f-8148-4b7a2379a64c
+        loanId: c8e27489-0381-438f-8148-4b7a2379a64c
         customerId: CustomerName-Production
         sessionid: NS-88be6e65-cdef-4bcc-8298-d6b09b577a33
         outputtype: Json
@@ -364,7 +369,7 @@ components:
     ProcessLoanReqAsync:
       summary: Asynchronous Process Loan Request
       value:
-        id: c8e27489-0381-438f-8148-4b7a2379a64c
+        loanId: c8e27489-0381-438f-8148-4b7a2379a64c
         customerId: CustomerName-Production
         sessionid: NS-88be6e65-cdef-4bcc-8298-d6b09b577a33
         outputtype: Json
@@ -390,7 +395,7 @@ components:
     ProcessLoanDocuments:
       summary: Process Loan Documents
       value:
-        id: c8e27489-0381-438f-8148-4b7a2379a64c
+        loanId: c8e27489-0381-438f-8148-4b7a2379a64c
         context: 6cea2800-eb9e-4cd5-8136-4dd11dadf388
         candorId: 68098e32-ce8f-41a9-9ce7-7127514348f2
         sessionid: NS-88be6e65-cdef-4bcc-8298-d6b09b577a33
@@ -398,6 +403,7 @@ components:
         inputDocuments:
         - fileId: 056960be-e703-4eeb-8f0a-3ea58063ba34
           bucket: loan-documents
+          filename: HelloWorld.pdf
           path: 029d4378-e479-4c53-a671-b3e89d829911/c8e27489-0381-438f-8148-4b7a2379a64c/input/371d3620-1c98-4466-9f95-290b7748594d
           status:
             code: 200
@@ -410,6 +416,7 @@ components:
             message: Duplicate request
         - fileId: 75717e24-8102-4140-9c01-5044928cae2e
           bucket: loan-documents
+          filename: FooBar.pdf
           path: 029d4378-e479-4c53-a671-b3e89d829911/c8e27489-0381-438f-8148-4b7a2379a64c/input/69f15f0d-ec1c-4a54-9798-9a2bd0803adb
           status:
             code: 400
@@ -428,7 +435,7 @@ components:
     ProcessLoanDocumentsWithDelete:
       summary: Process Loan Documents with Deleted Output Documents
       value:
-        id: c8e27489-0381-438f-8148-4b7a2379a64c
+        loanId: c8e27489-0381-438f-8148-4b7a2379a64c
         context: 6cea2800-eb9e-4cd5-8136-4dd11dadf388
         candorId: 68098e32-ce8f-41a9-9ce7-7127514348f2
         sessionid: NS-88be6e65-cdef-4bcc-8298-d6b09b577a33
@@ -436,6 +443,7 @@ components:
         inputDocuments:
         - fileId: 056960be-e703-4eeb-8f0a-3ea58063ba34
           bucket: loan-documents
+          filename: HelloWorld.pdf
           path: 029d4378-e479-4c53-a671-b3e89d829911/c8e27489-0381-438f-8148-4b7a2379a64c/input/371d3620-1c98-4466-9f95-290b7748594d
           status:
             code: 200
@@ -448,6 +456,7 @@ components:
             message: Duplicate request
         - fileId: 75717e24-8102-4140-9c01-5044928cae2e
           bucket: loan-documents
+          filename: FooBar.pdf
           path: 029d4378-e479-4c53-a671-b3e89d829911/c8e27489-0381-438f-8148-4b7a2379a64c/input/69f15f0d-ec1c-4a54-9798-9a2bd0803adb
           status:
             code: 400

--- a/decisions.openapi.yaml
+++ b/decisions.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api Decisions Communication
-  version: 0.10.0
+  version: 0.11.0-rc.1
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/decisions.openapi.yaml
+++ b/decisions.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api Decisions Communication
-  version: 0.11.0-rc.2
+  version: 0.11.0
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/decisions.openapi.yaml
+++ b/decisions.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api Decisions Communication
-  version: 0.11.0-rc.1
+  version: 0.11.0-rc.2
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog
@@ -302,8 +302,10 @@ components:
                       The processed status for this document
 
                       - 200: Successfully ICR'd
-                      - 250: Partially ICR'd
                       - 300: Duplicate Document Uploaded
+                      - 301: Illegible Document
+                      - 302: Ineligible Document
+                      - 350: Partially ICR'd
                       - 400: Document Corrupted, Unable to open, or Editable pdf
                       - 401: Unable to match Borrower name on document to applicant; Lender to review
                       - 402: Unable to match SSN on document to applicant; Lender to review
@@ -311,12 +313,15 @@ components:
                       - 404: Unable to match Company Name on document to application; Lender to review
                       - 405: Document is outdated per guideline requirements
                       - 406: Successfully ICR'd
-                      - 415: Out of scope document
-                      - 500: Ineligible Document
+                      - 500: Failed ICR'd
+                    # Input Document Status Result
+                    # 406 -> 200
                     enum:
                     - 200
-                    - 250
                     - 300
+                    - 301
+                    - 302
+                    - 350
                     - 400
                     - 401
                     - 402
@@ -324,7 +329,6 @@ components:
                     - 404
                     - 405
                     - 406
-                    - 415
                     - 500
                   message:
                     type: string

--- a/icr.openapi.yaml
+++ b/icr.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api ICR Communication
-  version: 0.11.0-rc.1
+  version: 0.11.0-rc.2
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog
@@ -328,6 +328,9 @@ components:
                       - 4003: Unsupported File Format
                       - 4004: Unable to process as document does not exist
                       - 4008: Duplicate Request
+                    # Input Document Status Result
+                    # 4003 -> 302
+                    # 4008 -> 300
                     enum:
                     - 2000
                     - 401
@@ -374,19 +377,19 @@ components:
                     type: integer
                     description: |
                       - 200: Successfully ICR'd
-                      - 250: Partially ICR'd
                       - 300: Duplicate Document Uploaded
+                      - 301: Illegible Document
+                      - 302: Ineligible Document
+                      - 350: Partially ICR'd
                       - 400: Document Corrupted, Unable to open, or Editable pdf
-                      - 406: Illegible
-                      - 415: Out of scope document
-                      - 500: Ineligible Document
+                      - 500: Failed ICR'd
                     enum:
                     - 200
-                    - 250
                     - 300
+                    - 301
+                    - 302
+                    - 350
                     - 400
-                    - 406
-                    - 415
                     - 500
                   message:
                     type: string

--- a/icr.openapi.yaml
+++ b/icr.openapi.yaml
@@ -105,8 +105,12 @@ paths:
                     schema:
                       $ref: '#/components/schemas/Callback'
               responses:
-                '2XX':
-                  description: We expect any successful response
+                '200':
+                  description: Request was received and individual document status will be reported in the response body.
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/DocumentsReceived'
                 default:
                   description: Any non-success response code will be logged.
       responses:
@@ -287,6 +291,54 @@ components:
       properties:
         context:
           $ref: 'schemas.yaml#/components/schemas/Context'
+    
+    DocumentsReceived:
+      type: object
+      title: Documents Received Response
+      required:
+        - inputDocuments
+      properties:
+        inputDocuments:
+          type: array
+          title: Input Document Statuses
+          description: A list of the input documents and their received status
+          minItems: 1
+          items:
+            title: Document Status
+            required:
+              - id
+              - status
+            properties:
+              id:
+                type: string
+                description: The unique identifier for this document. This should match the id in the DocumentsAvailable callback.
+              status:
+                type: object
+                required:
+                - code
+                - message
+                properties:
+                  code:
+                    type: integer
+                    description: |
+                      - 2000: Uploaded Successfully
+                      - 401: Unauthorized Access
+                      - 4000: Something went wrong
+                      - 4002: Mandatory Data is missing
+                      - 4003: Unsupported File Format
+                      - 4004: Unable to process as document does not exist
+                      - 4008: Duplicate Request
+                    enum:
+                    - 2000
+                    - 401
+                    - 4000
+                    - 4002
+                    - 4003
+                    - 4004
+                    - 4008
+                  message:
+                    type: string
+                    description: Descriptive text of the status
 
     DocumentsProcessed:
       type: object

--- a/icr.openapi.yaml
+++ b/icr.openapi.yaml
@@ -374,13 +374,19 @@ components:
                     type: integer
                     description: |
                       - 200: Successfully ICR'd
+                      - 250: Partial ICR'd
                       - 300: Duplicate Document Uploaded
                       - 400: Document Corrupted, Unable to open, or Editable pdf
+                      - 406: Illegible
+                      - 415: Out of scope document
                       - 500: Ineligible Document
                     enum:
                     - 200
+                    - 250
                     - 300
                     - 400
+                    - 406
+                    - 415
                     - 500
                   message:
                     type: string

--- a/icr.openapi.yaml
+++ b/icr.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api ICR Communication
-  version: 0.10.0
+  version: 0.11.0-rc.1
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/icr.openapi.yaml
+++ b/icr.openapi.yaml
@@ -374,7 +374,7 @@ components:
                     type: integer
                     description: |
                       - 200: Successfully ICR'd
-                      - 250: Partial ICR'd
+                      - 250: Partially ICR'd
                       - 300: Duplicate Document Uploaded
                       - 400: Document Corrupted, Unable to open, or Editable pdf
                       - 406: Illegible

--- a/icr.openapi.yaml
+++ b/icr.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api ICR Communication
-  version: 0.11.0-rc.2
+  version: 0.11.0
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/los.openapi.yaml
+++ b/los.openapi.yaml
@@ -86,7 +86,7 @@ paths:
               schema:
                 $ref: 'schemas.yaml#/components/schemas/CandorResult'
               example:
-                id: c8e27489-0381-438f-8148-4b7a2379a64c
+                loanId: c8e27489-0381-438f-8148-4b7a2379a64c
                 runId: 1
                 timestamp: '0001-01-01T00:00:00Z'
                 context: 6cea2800-eb9e-4cd5-8136-4dd11dadf388
@@ -100,7 +100,7 @@ paths:
                 assets: Pending
                 income: Pending
                 conditions:
-                - id: 151ce1d9-90e2-4e32-9337-8de6d8124e50
+                - conditionId: 151ce1d9-90e2-4e32-9337-8de6d8124e50
                   status: Unfulfilled
                   name: Condition Name
                   description: Extended descriptive text for this condition

--- a/los.openapi.yaml
+++ b/los.openapi.yaml
@@ -85,32 +85,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CandorResult'
-              # example:
-              #   loanId: c8e27489-0381-438f-8148-4b7a2379a64c
-              #   runId: 1
-              #   timestamp: '0001-01-01T00:00:00Z'
-              #   context: 6cea2800-eb9e-4cd5-8136-4dd11dadf388
-              #   insuranceScore: '75'
-              #   insuranceCovered: Pending
-              #   underwritingStatus: Conditional Approval
-              #   occupancy: Valid
-              #   identity: Valid
-              #   valuation: Pending
-              #   liabilities: Pending
-              #   assets: Pending
-              #   income: Pending
-              #   conditions:
-              #   - conditionId: 151ce1d9-90e2-4e32-9337-8de6d8124e50
-              #     status: Unfulfilled
-              #     name: Condition Name
-              #     description: Extended descriptive text for this condition
-              #     priorTo: PTD
-              #     owner: Lender
-              #     category: Credit
-              #   results:
-              #   - name: Findings.pdf
-              #     section: Candor - Findings Page
-              #     base64: SGVsbG8gV29ybGQ=
+              example:
+                loanId: c8e27489-0381-438f-8148-4b7a2379a64c
+                runId: 1
+                timestamp: '0001-01-01T00:00:00Z'
+                context: 6cea2800-eb9e-4cd5-8136-4dd11dadf388
+                insuranceScore: '75'
+                insuranceCovered: Pending
+                underwritingStatus: Conditional Approval
+                occupancy: Valid
+                identity: Valid
+                valuation: Pending
+                liabilities: Pending
+                assets: Pending
+                income: Pending
+                conditions:
+                - conditionId: 151ce1d9-90e2-4e32-9337-8de6d8124e50
+                  status: Unfulfilled
+                  name: Condition Name
+                  description: Extended descriptive text for this condition
+                  priorTo: PTD
+                  owner: Lender
+                  category: Credit
+                results:
+                - name: Findings.pdf
+                  section: Candor - Findings Page
+                  base64: SGVsbG8gV29ybGQ=
         '202':
           description: |
             Successful asynchronous response (no body returned).

--- a/los.openapi.yaml
+++ b/los.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api LOS Communication
-  version: 0.10.0
+  version: 0.11.0-rc.1
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/los.openapi.yaml
+++ b/los.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api LOS Communication
-  version: 0.11.0-rc.2
+  version: 0.11.0
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/los.openapi.yaml
+++ b/los.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Candor Api LOS Communication
-  version: 0.11.0-rc.1
+  version: 0.11.0-rc.2
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog
@@ -84,33 +84,33 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'schemas.yaml#/components/schemas/CandorResult'
-              example:
-                loanId: c8e27489-0381-438f-8148-4b7a2379a64c
-                runId: 1
-                timestamp: '0001-01-01T00:00:00Z'
-                context: 6cea2800-eb9e-4cd5-8136-4dd11dadf388
-                insuranceScore: '75'
-                insuranceCovered: Pending
-                underwritingStatus: Conditional Approval
-                occupancy: Valid
-                identity: Valid
-                valuation: Pending
-                liabilities: Pending
-                assets: Pending
-                income: Pending
-                conditions:
-                - conditionId: 151ce1d9-90e2-4e32-9337-8de6d8124e50
-                  status: Unfulfilled
-                  name: Condition Name
-                  description: Extended descriptive text for this condition
-                  priorTo: PTD
-                  owner: Lender
-                  category: Credit
-                results:
-                - name: Findings.pdf
-                  section: Candor - Findings Page
-                  base64: SGVsbG8gV29ybGQ=
+                $ref: '#/components/schemas/CandorResult'
+              # example:
+              #   loanId: c8e27489-0381-438f-8148-4b7a2379a64c
+              #   runId: 1
+              #   timestamp: '0001-01-01T00:00:00Z'
+              #   context: 6cea2800-eb9e-4cd5-8136-4dd11dadf388
+              #   insuranceScore: '75'
+              #   insuranceCovered: Pending
+              #   underwritingStatus: Conditional Approval
+              #   occupancy: Valid
+              #   identity: Valid
+              #   valuation: Pending
+              #   liabilities: Pending
+              #   assets: Pending
+              #   income: Pending
+              #   conditions:
+              #   - conditionId: 151ce1d9-90e2-4e32-9337-8de6d8124e50
+              #     status: Unfulfilled
+              #     name: Condition Name
+              #     description: Extended descriptive text for this condition
+              #     priorTo: PTD
+              #     owner: Lender
+              #     category: Credit
+              #   results:
+              #   - name: Findings.pdf
+              #     section: Candor - Findings Page
+              #     base64: SGVsbG8gV29ybGQ=
         '202':
           description: |
             Successful asynchronous response (no body returned).
@@ -167,6 +167,56 @@ components:
           description: A collection of document Ids previously uploaded to Candor.
           items:
             type: string
+
+    CandorResult:
+      type: object
+      allOf:
+      - $ref: 'schemas.yaml#/components/schemas/CandorResult'
+      properties:
+        documentsProcessed:
+          type: array
+          items:
+            type: object
+            title: Processed Document
+            properties:
+              id:
+                type: string
+                description: The original LOS File Id supplied to the Candor Api for this document
+              status:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    description: |
+                      The processed status for this document
+
+                      - 200: Successfully ICR'd
+                      - 300: Duplicate Document Uploaded
+                      - 301: Illegible Document
+                      - 302: Ineligible Document
+                      - 350: Partially ICR'd
+                      - 400: Document Corrupted, Unable to open, or Editable pdf
+                      - 401: Unable to match Borrower name on document to applicant; Lender to review
+                      - 402: Unable to match SSN on document to applicant; Lender to review
+                      - 403: Unable to match Employer on document to application; Lender to review
+                      - 404: Unable to match Company Name on document to application; Lender to review
+                      - 405: Document is outdated per guideline requirements
+                      - 500: Failed ICR'd
+                    enum:
+                    - 200
+                    - 300
+                    - 301
+                    - 302
+                    - 350
+                    - 400
+                    - 401
+                    - 402
+                    - 403
+                    - 404
+                    - 405
+                    - 500
+                  message:
+                    type: string
 
   examples:
     UploadDocumentRequest:

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Common definitions for Candor Api
-  version: 0.11.0-rc.1
+  version: 0.11.0-rc.2
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Common definitions for Candor Api
-  version: 0.11.0-rc.2
+  version: 0.11.0
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Common definitions for Candor Api
-  version: 0.10.0
+  version: 0.11.0-rc.1
 externalDocs:
   description: Changelog
   url: https://github.com/candorfintech/Candor.Api.OpenAPI#changelog

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -156,7 +156,7 @@ components:
         emails:
           type: array
           title: Emails
-          description: A list of emails to notify when a Candor Result is processed that contained new documents uploaded to the loan.
+          description: A list of emails to notify when a Candor Result is processed.
           items:
             type: object
             required:
@@ -188,7 +188,7 @@ components:
       type: object
       title: Candor Result
       properties:
-        id:
+        loanId:
           $ref: '#/components/schemas/LoanId'
         runId:
           type: integer
@@ -246,7 +246,7 @@ components:
           items:
             title: Condition
             properties:
-              id:
+              conditionId:
                 type: string
                 description: Unique identifier for the condition
               status:


### PR DESCRIPTION
- Add response object to ICR DocumentsAvailable callback
- Change Decision models of `id` to a named id: `loanId`, `conditionId`
- Added `filename` back to Decision `inputDocuments`
- Added new ICR status codes
- Updated Document status codes across all entities
